### PR TITLE
Don't retain votes when refreshing page in Firefox

### DIFF
--- a/views/voting.hbs
+++ b/views/voting.hbs
@@ -19,7 +19,7 @@
     <ul class="voting mini-card-container">
         {{#each round}}
             <li class="entrant1">
-                <input type="radio" name="round:{{id}}" id="entrant{{character1.id}}" value="{{character1.id}}" {{#if character1.voted}}checked="checked" disabled="disabled"{{/if}} {{#if character2.voted}}disabled="disabled"{{/if}} class="character-input" />
+                <input type="radio" name="round:{{id}}" id="entrant{{character1.id}}" value="{{character1.id}}" {{#if character1.voted}}checked="checked" disabled="disabled"{{/if}} {{#if character2.voted}}disabled="disabled"{{/if}} class="character-input" autocomplete="off" />
                 <label for="entrant{{character1.id}}" class="mini-card left">
                     <dl>
                         <dt>Image</dt>
@@ -32,7 +32,7 @@
                 </label>
             </li>
             <li class="entrant2">
-                <input type="radio" name="round:{{id}}" id="entrant{{character2.id}}" value="{{character2.id}}" {{#if character2.voted}}checked="checked" disabled="disabled"{{/if}} {{#if character1.voted}}disabled="disabled"{{/if}} class="character-input" />
+                <input type="radio" name="round:{{id}}" id="entrant{{character2.id}}" value="{{character2.id}}" {{#if character2.voted}}checked="checked" disabled="disabled"{{/if}} {{#if character1.voted}}disabled="disabled"{{/if}} class="character-input" autocomplete="off" />
                 <label for="entrant{{character2.id}}" class="mini-card right">
                     <dl>
                         <dt>Image</dt>


### PR DESCRIPTION
The votes cannot be retained when refreshing, because when loading the page the candidates are placed randomly left or right to remove bias. Reloading the page randomly swaps some candidates but doesn't swap the currently selected candidate. However Firefox autocompletes the form inputs with previously entered data upon refreshing.
This change brings the behaviour down to how it works in Chrome: No autocompletion based on votes before the refresh.

For documentation, see:
- https://www.w3schools.com/tags/att_input_autocomplete.asp
- https://stackoverflow.com/questions/7377301/firefox-keeps-form-data-on-reload
- https://www.w3.org/TR/html52/sec-forms.html#enabling-clientside-automatic-filling-of-form-controls

Fixes #32.